### PR TITLE
[club] 동아리 상태 및 개설/폐지 연도 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ DataGSM의 OAuth를 추상화된 환경에서 제공합니다.
 <dependency>
     <groupId>com.github.themoment-team</groupId>
     <artifactId>datagsm-oauth-sdk-java</artifactId>
-    <version>1.4.1</version>
+    <version>1.5.0</version>
 </dependency>
 ```
 ### 설치 - Gradle
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.themoment-team:datagsm-oauth-sdk-java:1.4.1'
+    implementation 'com.github.themoment-team:datagsm-oauth-sdk-java:1.5.0'
 }
 ```
 
@@ -38,7 +38,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.themoment-team:datagsm-oauth-sdk-java:1.4.1")
+    implementation("com.github.themoment-team:datagsm-oauth-sdk-java:1.5.0")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "team.themoment.datagsm.sdk"
-version = "1.4.1"
+version = "1.5.0"
 
 java {
     toolchain {

--- a/src/main/java/team/themoment/datagsm/sdk/oauth/model/ClubInfo.java
+++ b/src/main/java/team/themoment/datagsm/sdk/oauth/model/ClubInfo.java
@@ -7,6 +7,9 @@ public class ClubInfo {
     private Long id;
     private String name;
     private ClubType type;
+    private ClubStatus status;
+    private Integer foundedYear;
+    private Integer abolishedYear;
 
     public ClubInfo() {}
 
@@ -34,12 +37,39 @@ public class ClubInfo {
         this.type = type;
     }
 
+    public ClubStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ClubStatus status) {
+        this.status = status;
+    }
+
+    public Integer getFoundedYear() {
+        return foundedYear;
+    }
+
+    public void setFoundedYear(Integer foundedYear) {
+        this.foundedYear = foundedYear;
+    }
+
+    public Integer getAbolishedYear() {
+        return abolishedYear;
+    }
+
+    public void setAbolishedYear(Integer abolishedYear) {
+        this.abolishedYear = abolishedYear;
+    }
+
     @Override
     public String toString() {
         return "ClubInfo{" +
                 "id=" + id +
                 ", name='" + name + '\'' +
                 ", type=" + type +
+                ", status=" + status +
+                ", foundedYear=" + foundedYear +
+                ", abolishedYear=" + abolishedYear +
                 '}';
     }
 }

--- a/src/main/java/team/themoment/datagsm/sdk/oauth/model/ClubStatus.java
+++ b/src/main/java/team/themoment/datagsm/sdk/oauth/model/ClubStatus.java
@@ -1,0 +1,9 @@
+package team.themoment.datagsm.sdk.oauth.model;
+
+/**
+ * 동아리 운영 상태
+ */
+public enum ClubStatus {
+    ACTIVE,    // 운영 중
+    ABOLISHED  // 폐지
+}


### PR DESCRIPTION
## Description

datagsm-server PR #242 변경사항에 맞춰 `ClubInfo` 모델에 동아리 운영 상태 및 학년도 필드를 추가했습니다.

## Changes

- `ClubStatus` enum 신규 추가 (`ACTIVE`, `ABOLISHED`)
- `ClubInfo`에 `status` (운영 상태) 필드 추가
- `ClubInfo`에 `foundedYear` (창설 학년도) 필드 추가
- `ClubInfo`에 `abolishedYear` (폐지 학년도, nullable) 필드 추가

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Checklist

- [x] 코드가 정상적으로 빌드됩니다
- [ ] 관련 테스트를 추가하거나 업데이트했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] Breaking change가 있다면 마이그레이션 가이드를 작성했습니다

## Migration Guide

`ClubInfo` 역직렬화 시 서버 응답에 `status`, `foundedYear` 필드가 필수로 포함됩니다. SDK를 업그레이드하는 경우 해당 필드를 처리하도록 코드를 수정해주세요.

| 필드 | 타입 | 필수 여부 | 설명 |
|------|------|-----------|------|
| `status` | `ClubStatus` | 필수 | `ACTIVE`(운영 중) 또는 `ABOLISHED`(폐지) |
| `foundedYear` | `Integer` | 필수 | 창설 학년도 (예: 2022) |
| `abolishedYear` | `Integer` | 선택 | 폐지 학년도, 운영 중인 경우 `null` |

## Related Issues

Closes # (datagsm-server#242 반영)